### PR TITLE
Update Invoke-TvCommand.ps1

### DIFF
--- a/tvbot/public/Invoke-TvCommand.ps1
+++ b/tvbot/public/Invoke-TvCommand.ps1
@@ -73,7 +73,7 @@ function Invoke-TvCommand {
             throw "Conversion for UserCommand and AdminCommand failed. Please check examples."
         }
 
-        $allowedregex = [Regex]::new("^$Key[a-zA-Z0-9\ ]+`$")
+        $allowedregex = [Regex]::new("^$([Regex]::Escape($Key))[a-zA-Z0-9\ ]+`$")
         $irctagregex = [Regex]::new('^(?:@([^ ]+) )?(?:[:]((?:(\w+)!)?\S+) )?(\S+)(?: (?!:)(.+?))?(?: [:](.+))?$')
 
         foreach ($object in $InputObject) {


### PR DESCRIPTION
Escaped the $Key variable in $allowedregex so that people can use otherwise special regex characters as command keys.
Hopefully this should do it!